### PR TITLE
fix: Remove wrong dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,5 +6,5 @@
 To verify the generator before publishing:
 
 1. Run `npm pack` in this repository to produce a tarball (for example `create-tinker-stack-0.2.2.tgz`).
-2. In a temporary directory, execute `npx --yes create-tinker-stack@file:/absolute/path/to/create-tinker-stack-0.2.2.tgz`.
+2. In a temporary directory, execute `npx --yes create-tinker-stack@file://$(pwd)/create-tinker-stack-0.2.3.tgz`.
     - Replace the path with the absolute path to the tarball from step 1 (npm `create` does not currently support `file:` specifiers).

--- a/template/api/package.json
+++ b/template/api/package.json
@@ -17,9 +17,6 @@
     "@repo/eslint-config": "*",
     "@repo/typescript-config": "*"
   },
-  "peerDependencies": {
-    "msw": "^2.4.9"
-  },
   "engines": {
     "node": ">=22.0.0"
   },
@@ -42,9 +39,5 @@
     "*.{json,md}": [
       "prettier --write"
     ]
-  },
-  "dependencies": {
-    "memoize": "^10.0.0",
-    "msw": "^2.4.9"
   }
 }

--- a/template/mock-backend/package.json
+++ b/template/mock-backend/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@repo/api": "*",
-    "@repo/mock-data": "2024.0.0",
+    "@repo/mock-data": "*",
     "@tinyhttp/cookie": "^2.1.1",
     "memoize": "^10.0.0",
     "msw": "^2.4.9",


### PR DESCRIPTION
Removed a redundant dependency in the API package.

Removed a version number of an internal module in mock-backend.